### PR TITLE
Make the mailusername case-insensitive

### DIFF
--- a/dca/tl_member.php
+++ b/dca/tl_member.php
@@ -18,3 +18,4 @@ $GLOBALS['TL_DCA']['tl_member']['fields']['email']['eval']['unique'] = true;
 $GLOBALS['TL_DCA']['tl_member']['fields']['username']['eval']['rgxp'] = 'email';
 $GLOBALS['TL_DCA']['tl_member']['fields']['username']['eval']['disabled'] = true;
 $GLOBALS['TL_DCA']['tl_member']['fields']['username']['eval']['mandatory'] = false;
+$GLOBALS['TL_DCA']['tl_member']['fields']['username']['sql'] = "varchar(255) COLLATE utf8_general_ci NULL";

--- a/dca/tl_member.php
+++ b/dca/tl_member.php
@@ -15,7 +15,8 @@
  */
 $GLOBALS['TL_DCA']['tl_member']['fields']['email']['save_callback'][] = array('MailUsername', 'saveMemberEmail');
 $GLOBALS['TL_DCA']['tl_member']['fields']['email']['eval']['unique'] = true;
+$GLOBALS['TL_DCA']['tl_member']['fields']['email']['eval']['maxlength'] = 64;
 $GLOBALS['TL_DCA']['tl_member']['fields']['username']['eval']['rgxp'] = 'email';
 $GLOBALS['TL_DCA']['tl_member']['fields']['username']['eval']['disabled'] = true;
 $GLOBALS['TL_DCA']['tl_member']['fields']['username']['eval']['mandatory'] = false;
-$GLOBALS['TL_DCA']['tl_member']['fields']['username']['sql'] = "varchar(255) COLLATE utf8_general_ci NULL";
+$GLOBALS['TL_DCA']['tl_member']['fields']['username']['sql'] = "varchar(64) COLLATE utf8_general_ci NULL";


### PR DESCRIPTION
It is a well-discussed topic in the Contao community and I wonder how it didn't get onto GitHub.
In all projects with mailusername users cope with problems according the case-sensitive email address. Some users lock out of their account.
So I propose to treat the username as case insensitive by altering the sql definition.
The modified sql definition will
* treat the username (=email address) as case-insensitive and
* allow up to 255 characters (this is the same limit used for the email field).
I'm aware of the counter-argument of decreasing the all over security.
