### PR TITLE
Check for existing username in save_callback

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -7,3 +7,4 @@ services:
     Terminal42\MailusernameBundle\EventListener\MailUsernameListener:
         arguments:
             - '@database_connection'
+            - '@translator'


### PR DESCRIPTION
There can be edge cases where the following error occurs:

```
PDOException: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'foobar@example.com' for key 'username'
```

during the `createNewUser` hook. This can occur when parallel requests with the same POST data are processed. This is hard to reproduce though. In the real world it can only happen with browsers that allow sending the same form multiple times (by clicking the submit button multiple times) - which most modern browsers don't (I can only reproduce it sometimes with Internet Explorer).

This PR introduces an additional safety check in the `save_callback` for `tl_member.email`, so that the form will not validate, if a username with the same e-mail address is already in the database at this point in time.